### PR TITLE
Add step to initialize sub-module to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Pixel art editor with algorithmic tools.
 To build:
 
 ```bash
+git submodule update --init --recursive
 cargo run --bin xprite-native --release
 ```
 


### PR DESCRIPTION
Project won't build without sub-module initialization, leading to confusing error when following README instructions.